### PR TITLE
Fix crash when clearing cache or buffers when DB unconnected. (#80)

### DIFF
--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -472,6 +472,12 @@ namespace SQLQueryStress
 
         private void btnCleanBuffer_Click(object sender, EventArgs e)
         {
+            if (!_settings.MainDbConnectionInfo.TestConnection())
+            {
+                MessageBox.Show(Resources.MustSetValidDbConnInfo);
+                return;
+            }
+
             MessageBox.Show(LoadEngine.ExecuteCommand(_settings.MainDbConnectionInfo.ConnectionString, "DBCC DROPCLEANBUFFERS")
                 ? "Buffers cleared"
                 : "Errors encountered");
@@ -479,6 +485,12 @@ namespace SQLQueryStress
 
         private void btnFreeCache_Click(object sender, EventArgs e)
         {
+            if (!_settings.MainDbConnectionInfo.TestConnection())
+            {
+                MessageBox.Show(Resources.MustSetValidDbConnInfo);
+                return;
+            }
+
             MessageBox.Show(LoadEngine.ExecuteCommand(_settings.MainDbConnectionInfo.ConnectionString, "DBCC FREEPROCCACHE")
                 ? "Cache freed"
                 : "Errors encountered");


### PR DESCRIPTION
* Sort out a bunch of warning messages and formatting issues.

* Fix Visual Studio warnings,
fix crash when clicking Free Cache or Clean Buffers buttons,
add a UI Update framerate limiter when running tests, to minimise CPU use when many threads finish per second.

* try removing the code analyser?

* Revert "try removing the code analyser?"

This reverts commit 900c9d004f3fc0f39cecb0ed124673f59a2e856b.

* Revert "Fix Visual Studio warnings,"

This reverts commit 91d127e410d1d56575a8da3225c6a5f3ed15c1d2.

* Revert "Sort out a bunch of warning messages and formatting issues."

This reverts commit f93a0f6a089de77286f0e1a36c12f431c7484818.

* check db is connected before clearing cache or buffers.

* fix all current build warnings, except for naming conventions which have been added to new suppression file.

* Revert "fix all current build warnings, except for naming conventions which have been added to new suppression file."

This reverts commit c13070ad343885240f35bfffc9f7a025d42af434.