### PR TITLE
Fix some build warnings, allow project to use latest C# language vers…

### DIFF
--- a/src/SQLQueryStress/CommandLineParser/Text/CopyrightInfo.cs
+++ b/src/SQLQueryStress/CommandLineParser/Text/CopyrightInfo.cs
@@ -40,9 +40,9 @@ namespace CommandLine.Text
         private readonly bool isSymbolUpper;
         private readonly int[] years;
         private readonly string author;
-        private static readonly string defaultCopyrightWord = "Copyright";
-        private static readonly string symbolLower = "(c)";
-        private static readonly string symbolUpper = "(C)";
+        private const string defaultCopyrightWord = "Copyright";
+        private const string symbolLower = "(c)";
+        private const string symbolUpper = "(C)";
         private StringBuilder builder;
 
         /// <summary>
@@ -88,8 +88,8 @@ namespace CommandLine.Text
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown when parameter <paramref name="years"/> is not supplied.</exception>
         public CopyrightInfo(bool isSymbolUpper, string author, params int[] years)
         {
-            Validator.CheckIsNullOrEmpty(author, "author");
-            Validator.CheckZeroLength(years, "years");
+            Validator.CheckIsNullOrEmpty(author, nameof(author));
+            Validator.CheckZeroLength(years, nameof(years));
 
             const int extraLength = 10;
             this.isSymbolUpper = isSymbolUpper; //this.symbol = symbol;

--- a/src/SQLQueryStress/CommandLineParser/Text/HelpText.cs
+++ b/src/SQLQueryStress/CommandLineParser/Text/HelpText.cs
@@ -46,7 +46,7 @@ namespace CommandLine.Text
         private string copyright;
         private StringBuilder preOptionsHelp;
         private StringBuilder optionsHelp;
-        private static readonly string defaultRequiredWord = "Required.";
+        private const string defaultRequiredWord = "Required.";
         #endregion
 
         private HelpText()

--- a/src/SQLQueryStress/ConnectionInfo.cs
+++ b/src/SQLQueryStress/ConnectionInfo.cs
@@ -117,7 +117,7 @@ namespace SQLQueryStress
                 {
                     conn.Open();
                 }
-                catch (Exception exc)
+                catch (Exception)
                 {
                     return false;
                 }

--- a/src/SQLQueryStress/DatabaseSelect.cs
+++ b/src/SQLQueryStress/DatabaseSelect.cs
@@ -284,7 +284,7 @@ namespace SQLQueryStress
                 {
                     ApplicationIntent applicationIntent;
 
-                    Enum.TryParse<ApplicationIntent>(pm_appintent_combo.Text, out applicationIntent);
+                    _ = Enum.TryParse<ApplicationIntent>(pm_appintent_combo.Text, out applicationIntent);
 
                     _localParamConnectionInfo.ApplicationIntent = applicationIntent;
                 }
@@ -320,7 +320,7 @@ namespace SQLQueryStress
             {
                 ApplicationIntent applicationIntent;
 
-                Enum.TryParse<ApplicationIntent>(appintent_combo.Text, out applicationIntent);
+                _ = Enum.TryParse<ApplicationIntent>(appintent_combo.Text, out applicationIntent);
 
                 _localMainConnectionInfo.ApplicationIntent = applicationIntent;
             }

--- a/src/SQLQueryStress/Properties/Resources.Designer.cs
+++ b/src/SQLQueryStress/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace SQLQueryStress.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/src/SQLQueryStress/Properties/Settings.Designer.cs
+++ b/src/SQLQueryStress/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace SQLQueryStress.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.5.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/src/SQLQueryStress/SQLQueryStress.csproj
+++ b/src/SQLQueryStress/SQLQueryStress.csproj
@@ -42,6 +42,8 @@
     <ApplicationVersion>0.9.0.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -53,8 +55,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>5</LangVersion>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -66,6 +67,8 @@
     <CodeAnalysisRules>
     </CodeAnalysisRules>
     <Prefer32Bit>false</Prefer32Bit>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ICSharpCode.AvalonEdit, Version=5.0.1.0, Culture=neutral, PublicKeyToken=9cc39be672370310, processorArchitecture=MSIL">


### PR DESCRIPTION
…ion (#81)

* Sort out a bunch of warning messages and formatting issues.

* Fix Visual Studio warnings,
fix crash when clicking Free Cache or Clean Buffers buttons,
add a UI Update framerate limiter when running tests, to minimise CPU use when many threads finish per second.

* try removing the code analyser?

* Revert "try removing the code analyser?"

This reverts commit 900c9d004f3fc0f39cecb0ed124673f59a2e856b.

* Revert "Fix Visual Studio warnings,"

This reverts commit 91d127e410d1d56575a8da3225c6a5f3ed15c1d2.

* Revert "Sort out a bunch of warning messages and formatting issues."

This reverts commit f93a0f6a089de77286f0e1a36c12f431c7484818.

* check db is connected before clearing cache or buffers.

* fix all current build warnings, except for naming conventions which have been added to new suppression file.

* Revert "fix all current build warnings, except for naming conventions which have been added to new suppression file."

This reverts commit c13070ad343885240f35bfffc9f7a025d42af434.

* fix some code analysis warnings

* try upgrading to .NET Framework 4.7.1

* remove hard coded C#5 requirement and turn on all MS warnings for Debug config

* fix some code analysis warnings

* try upgrading to .NET Framework 4.7.1

* remove hard coded C#5 requirement and turn on all MS warnings for Debug config

* revert back to .NET 4.6.1 as most users should have this

* fix some code analysis warnings

* try upgrading to .NET Framework 4.7.1

* remove hard coded C#5 requirement and turn on all MS warnings for Debug config

* revert back to .NET 4.6.1 as most users should have this

* try upgrading to .NET Framework 4.7.1

* Revert "try upgrading to .NET Framework 4.7.1"

This reverts commit b3dbcbc5dd957aa216b6b86ebcb7cab58bcb4400.